### PR TITLE
Cygwin support/compatibility

### DIFF
--- a/teradata/tdodbc.py
+++ b/teradata/tdodbc.py
@@ -99,7 +99,7 @@ QUERY_TIMEOUT = 120
 if pyVer > 2:
     unicode = str  # @ReservedAssignment
 
-if osType == "Darwin" or osType == "Windows":
+if osType == "Darwin" or osType == "Windows" or osType.startswith('CYGWIN'):
     # Mac OSx and Windows
     _createBuffer = lambda l: ctypes.create_unicode_buffer(l)
     _inputStr = lambda s, l = None: None if s is None else \
@@ -269,6 +269,8 @@ def initOdbcLibrary(odbcLibPath=None):
                 # If MAC OSx
                 if osType == "Darwin":
                     odbcLibPath = "libiodbc.dylib"
+                elif osType.startswith("CYGWIN"):
+                    odbcLibPath = "odbc32.dll"
                 else:
                     odbcLibPath = 'libodbc.so'
             logger.info("Loading ODBC Library: %s", odbcLibPath)


### PR DESCRIPTION
[Cygwin](https://www.cygwin.com/) is a popular POSIX environment under MS WIndows that works by providing a POSIX compatibility layer on top of MS Windows API. To make `teradata.tdodbc` work under Cygwin, requires minimal changes and (from what I see) doesn't affect any existing functionality. 

Is it possible to include Cygwin support/compatibility? I understand if Teradata doesn't officially support Cygwin, but these changes will enable someone to use `teradata.tdodbc` under Cygwin at one's own risk without having to create an entirely new package.

Thanks