### PR TITLE
Expose columns in udaexec cursor

### DIFF
--- a/teradata/udaexec.py
+++ b/teradata/udaexec.py
@@ -775,6 +775,7 @@ class UdaExecCursor:
                 self.description = self.cursor.description
                 self.types = self.cursor.types
                 self.rowcount = self.cursor.rowcount
+                self.columns = self.cursor.columns
                 duration = time.time() - start
                 rowsStr = " " if self.cursor.rowcount < 0 else \
                     " Rows: %s, " % self.cursor.rowcount


### PR DESCRIPTION
You should be able to access the columns of the result set from the cursor, and not just from the individual output rows.