### PR TITLE
ValueError: Invalid placeholder in string: ==> Special character "$" in password

### DIFF
--- a/teradata/udaexec.py
+++ b/teradata/udaexec.py
@@ -559,7 +559,8 @@ class UdaExecConfig:
             sections = [self.configSection]
         for key, value in d.items():
             if util.isString(value):
-                d[key] = self._resolve(value, sections, None, None)
+                if str(key) == "username":
+                    d[key] = self._resolve(value, sections, None, None)
         return d
 
     def resolve(self, value, sections=None, default=None, errorMsg=None):


### PR DESCRIPTION
If password of teradata server contains special character "$" then following exception will be thrown and execution is termination

    return udaExec.connect(method=method, system=system, username=username, password=password)
  File "C:\Python27\lib\site-packages\teradata\udaexec.py", line 149, in connect
    args.update(self.config.resolveDict(kwargs))
  File "C:\Python27\lib\site-packages\teradata\udaexec.py", line 563, in resolveDict
    d[key] = self._resolve(value, sections, None, None)
  File "C:\Python27\lib\site-packages\teradata\udaexec.py", line 584, in _resolve
    value.replace("$$", "$$$$")).substitute(**s)
  File "C:\Python27\lib\string.py", line 176, in substitute
    return self.pattern.sub(convert, self.template)
  File "C:\Python27\lib\string.py", line 173, in convert
    self._invalid(mo)
  File "C:\Python27\lib\string.py", line 146, in _invalid
    (lineno, colno))
ValueError: Invalid placeholder in string: line 1, col 12
2016-07-12 16:34:49,221.221.999883652:teradata.udaexec:4840:INFO:9928:UdaExec exiting.
