### PR TITLE
Add database parameter

### DIFF
--- a/teradata/tdodbc.py
+++ b/teradata/tdodbc.py
@@ -382,8 +382,8 @@ class OdbcConnection:
 
     """Represents a Connection to Teradata using ODBC."""
 
-    def __init__(self, dbType="Teradata", system=None,
-                 username=None, password=None, autoCommit=False,
+    def __init__(self, dbType="Teradata", system=None, username=None,
+                 password=None, database=None, autoCommit=False,
                  transactionMode=None, queryBands=None, odbcLibPath=None,
                  dataTypeConverter=datatypes.DefaultDataTypeConverter(),
                  driver=None, **kwargs):
@@ -409,6 +409,8 @@ class OdbcConnection:
             connectParams["UID"] = username
         if password:
             connectParams["PWD"] = password
+        if database:
+           connectParams["DATABASE"] = database
         if transactionMode:
             connectParams["SESSIONMODE"] = "Teradata" \
                 if transactionMode == "TERA" else transactionMode


### PR DESCRIPTION
This allows the user to specify a database to connect to. For example, there might be some database db1 in dbc. We'd like to connect to the user dbc but execute statements inside database db1 (to create tables for example.).