### PR TITLE
Fix unicode port conversion

### DIFF
--- a/teradata/tdrest.py
+++ b/teradata/tdrest.py
@@ -83,9 +83,9 @@ class RestConnection:
         self.autoCommit = False
         if port is None:
             if protocol == 'http':
-                port = 1080
+                port = '1080'
             elif protocol == 'https':
-                port = 1443
+                port = '1443'
             else:
                 raise InterfaceError(
                     CONFIG_ERROR, "Unsupported protocol: {}".format(protocol))
@@ -349,11 +349,12 @@ class HttpConnection:
 
     def __init__(self, template):
         self.template = template
+        host = template.host + ":" + template.port
         if template.protocol.lower() == "http":
-            self.conn = httplib.HTTPConnection(template.host, template.port)
+            self.conn = httplib.HTTPConnection(host)
         elif template.protocol.lower() == "https":
             self.conn = httplib.HTTPSConnection(
-                template.host, template.port, context=template.sslContext)
+                host, context=template.sslContext)
         else:
             raise InterfaceError(
                 REST_ERROR, "Unknown protocol: %s" % template.protocol)


### PR DESCRIPTION
All key/value pairs from the config are converted to unicode but `httplib` does not accept unicode for the port; only number or string. 

```py
httplib.HTTPSConnection(u'example.com', u'1443')
```

This converts the host string to unicode by combining the host and port given (`u"example.com:1443"`) and allowing httplib to parse the port out of the unicode.

```py
httplib.HTTPSConnection(u"example.com:1443")
```

This error only shows up when the port is set in a configuration file. 