### PR TITLE
Exit early for STRING datatypes

### DIFF
--- a/teradata/datatypes.py
+++ b/teradata/datatypes.py
@@ -47,15 +47,15 @@ secondIntervalRegEx = re.compile("^(-?)(\d+\.?\d*)$")
 periodRegEx1 = re.compile("\('(.*)',\s*'(.*)'\)")
 periodRegEx2 = re.compile("ResultStruct:PERIOD\(.*\)\[(.*),\s*(.*)\]")
 
-NUMBER_TYPES = ("BYTEINT", "BIGINT", "DECIMAL", "DOUBLE", "DOUBLE PRECISION",
+NUMBER_TYPES = {"BYTEINT", "BIGINT", "DECIMAL", "DOUBLE", "DOUBLE PRECISION",
                 "INTEGER", "NUMBER", "SMALLINT", "FLOAT", "INT", "NUMERIC",
-                "REAL")
+                "REAL"}
 
-INT_TYPES = ("BYTEINT", "BIGINT", "INTEGER", "SMALLINT", "INT")
+INT_TYPES = {"BYTEINT", "BIGINT", "INTEGER", "SMALLINT", "INT"}
 
-FLOAT_TYPES = ("FLOAT", "DOUBLE", "DOUBLE PRECISION", "REAL")
+FLOAT_TYPES = {"FLOAT", "DOUBLE", "DOUBLE PRECISION", "REAL"}
 
-BINARY_TYPES = ("BLOB", "BYTE", "VARBYTE")
+BINARY_TYPES = {"BLOB", "BYTE", "VARBYTE"}
 
 
 def _getMs(m, num):
@@ -230,7 +230,9 @@ class DefaultDataTypeConverter (DataTypeConverter):
         logger.trace(
             "Converting \"%s\" to (%s, %s).", value, dataType, typeCode)
         if value is not None:
-            if typeCode == NUMBER:
+            if typecode == STRING:
+                return value
+            elif typeCode == NUMBER:
                 try:
                     return NUMBER(value)
                 except:


### PR DESCRIPTION
Two small performance improvements: 

- In `convertValue`, if `typeCode` is `STRING` the long `if...elif...else` sequence is short-circuited.
- Lists of types (`NUMBER_TYPES`, `INT_TYPES`, etc. are cast to sets for O(1) lookups. 