### PR TITLE
Improve performance of _getRow and fetchall

### DIFF
--- a/teradata/tdodbc.py
+++ b/teradata/tdodbc.py
@@ -85,6 +85,8 @@ SQLRETURN = SQLSMALLINT
 SQLPOINTER = ctypes.c_void_p
 SQLHANDLE = ctypes.c_void_p
 
+SQLWCHAR_SIZE = ctypes.sizeof(SQLWCHAR)
+
 ADDR = ctypes.byref
 PTR = ctypes.POINTER
 ERROR_BUFFER_SIZE = 2 ** 10
@@ -766,7 +768,7 @@ class OdbcCursor (util.Cursor):
                 paramArrays.append((SQLDOUBLE * paramSetSize)())
             else:
                 maxLen += 1
-                valueSize = SQLLEN(ctypes.sizeof(SQLWCHAR) * maxLen)
+                valueSize = SQLLEN(SQLWCHAR_SIZE * maxLen)
                 paramArrays.append(_createBuffer(paramSetSize * maxLen))
             lengthArrays.append((SQLLEN * paramSetSize)())
             for paramSetNum in range(0, paramSetSize):
@@ -1125,7 +1127,7 @@ def _getRow(cursor, buffers, bufSizes, dataTypes, indicators, rowIndex):
             elif dataType == SQL_LONGVARBINARY:
                 val = _getLobData(cursor, col, buf, True)
             else:
-                chLen = (int)(bufSize / ctypes.sizeof(SQLWCHAR))
+                chLen = (bufSize // SQLWCHAR_SIZE)
                 chBuf = (SQLWCHAR * chLen)
                 val = _outputStr(chBuf.from_buffer(buf,
                                                    bufSize * rowIndex))

--- a/teradata/util.py
+++ b/teradata/util.py
@@ -42,6 +42,7 @@ def trace(self, message, *args, **kws):
     # Yes, logger takes its '*args' as 'args'.
     if self.isEnabledFor(TRACE):
         self._log(TRACE, message, args, **kws)
+
 logging.TRACE = TRACE
 logging.Logger.trace = trace
 
@@ -125,20 +126,15 @@ class Cursor:
             size = self.arraysize
         self.fetchSize = size
         rows = []
-        count = 0
-        for row in self:
+        for row, count in enumerate(self):
             rows.append(row)
-            count += 1
             if count == size:
                 break
         return rows
 
     def fetchall(self):
         self.fetchSize = self.arraysize
-        rows = []
-        for row in self:
-            rows.append(row)
-        return rows
+        return list(self)
 
     def nextset(self):
         # Abstract method, defined by convention only


### PR DESCRIPTION
Performance improvements included in this PR:
- Store `ctypes.sizeof(SQLWCHAR)` once rather than re-calculating on each value conversion
- Return `list(self)` in `fetchall` instead of using a `for` loop

Cheers!