### PR TITLE
Cast datatype lists as set for faster lookup

### DIFF
--- a/teradata/datatypes.py
+++ b/teradata/datatypes.py
@@ -47,15 +47,15 @@ secondIntervalRegEx = re.compile("^(-?)(\d+\.?\d*)$")
 periodRegEx1 = re.compile("\('(.*)',\s*'(.*)'\)")
 periodRegEx2 = re.compile("ResultStruct:PERIOD\(.*\)\[(.*),\s*(.*)\]")
 
-NUMBER_TYPES = ("BYTEINT", "BIGINT", "DECIMAL", "DOUBLE", "DOUBLE PRECISION",
+NUMBER_TYPES = {"BYTEINT", "BIGINT", "DECIMAL", "DOUBLE", "DOUBLE PRECISION",
                 "INTEGER", "NUMBER", "SMALLINT", "FLOAT", "INT", "NUMERIC",
-                "REAL")
+                "REAL"}
 
-INT_TYPES = ("BYTEINT", "BIGINT", "INTEGER", "SMALLINT", "INT")
+INT_TYPES = {"BYTEINT", "BIGINT", "INTEGER", "SMALLINT", "INT"}
 
-FLOAT_TYPES = ("FLOAT", "DOUBLE", "DOUBLE PRECISION", "REAL")
+FLOAT_TYPES = {"FLOAT", "DOUBLE", "DOUBLE PRECISION", "REAL"}
 
-BINARY_TYPES = ("BLOB", "BYTE", "VARBYTE")
+BINARY_TYPES = {"BLOB", "BYTE", "VARBYTE"}
 
 
 def _getMs(m, num):


### PR DESCRIPTION
Similar to #84 but without breaking type conversion for string-like datatypes (e.g. JSON). 

Cheers!