### PR TITLE
Skip directories when cleaning up logs, update doc link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The module is hosted on PyPi: https://pypi.python.org/pypi/teradata
 DOCUMENTATION
 -------------
 
-Documentation for the Teradata Python Module is available on the <a href="https://developer.teradata.com/tools/reference/teradata-python-module">Teradata Developer Exchange</a>.
+Documentation for the Teradata Python Module is available on the <a href="https://downloads.teradata.com/tools/reference/teradata-python-module">Teradata Downloads site</a>.
 
 UNIT TESTS
 ----------

--- a/teradata/udaexec.py
+++ b/teradata/udaexec.py
@@ -275,7 +275,7 @@ class UdaExec:
         count = 0
         for f in os.listdir(logDir):
             f = os.path.join(logDir, f)
-            if os.stat(f).st_mtime < cutoff:
+            if os.path.isfile(f) and os.stat(f).st_mtime < cutoff:
                 logMsgs.append(
                     (logging.DEBUG, "Removing log file: {}".format(f)))
                 os.remove(f)


### PR DESCRIPTION
If the log directory contains subdirectories, the cleanup logic raised an error IsADirectoryError. I propose a change to skip directories.

I also updated the link to documentation in README file.